### PR TITLE
Use g1_read_raw_checked.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ crossbeam = "0.7"
 ff = { version = "0.2.1", package = "fff" }
 blake2b_simd = "0.5.8"
 bellperson = "0.9.0"
-# paired = "0.20.0"
-paired = { git = "https://github.com/filecoin-project/pairing", branch = "g1-read-raw-check" }
+paired = "0.20.1"
 groupy = "0.3.0"
 rand_chacha = "0.2.1"
 rayon = "1.2.1"

--- a/src/small.rs
+++ b/src/small.rs
@@ -753,7 +753,11 @@ pub fn read_g1<R: Read>(mut reader: R) -> io::Result<G1Affine> {
 #[inline]
 fn load_g1<R: Read>(mut reader: R, raw: bool, check_raw: bool) -> io::Result<G1Affine> {
     if raw {
-        G1Affine::read_raw(&mut reader, check_raw)
+        if check_raw {
+            G1Affine::read_raw_checked(&mut reader)
+        } else {
+            G1Affine::read_raw(&mut reader)
+        }
     } else {
         read_g1(reader)
     }

--- a/tests/small.rs
+++ b/tests/small.rs
@@ -208,7 +208,7 @@ fn test_small_file_io() {
     {
         let file = File::open(SMALL_PATH).unwrap();
         let mut reader = BufReader::with_capacity(1024 * 1024, file);
-        let small_read = MPCSmall::read(&mut reader, false).unwrap();
+        let small_read = MPCSmall::read(&mut reader, false, false).unwrap();
         assert_eq!(small_read, small_params);
         assert!(large_params.has_last_contrib(&small_read));
     };


### PR DESCRIPTION
Use `read_g1_raw_checked` from `pairing` to avoid the need for a breaking release.

- [x] Remove patch of  crates.io in `Cargo.toml` before merging.
- [x] Bump to explicitly use pairing `0.20.1` once released.